### PR TITLE
fix: Range Toggle (Frontify)

### DIFF
--- a/src/components/RangeSetting/RangeSetting.tsx
+++ b/src/components/RangeSetting/RangeSetting.tsx
@@ -122,6 +122,8 @@ export const RangeSetting: FC<RangeSettingProps> = ({
                                 }
                             }
 
+                            setLocalDimension({ ...localDimension, ...partial });
+
                             dispatch({
                                 type: ActionType.EditDimensions,
                                 payload: {

--- a/src/components/RangeSetting/RangeSetting.tsx
+++ b/src/components/RangeSetting/RangeSetting.tsx
@@ -156,6 +156,8 @@ export const RangeSetting: FC<RangeSettingProps> = ({
                                     partial.defaultValue = valueAsNumber + STEP;
                                 }
 
+                                setLocalDimension({ ...localDimension, ...partial });
+
                                 dispatch({
                                     type: ActionType.EditDimensions,
                                     payload: {
@@ -176,15 +178,19 @@ export const RangeSetting: FC<RangeSettingProps> = ({
                         <EditableTextWrapper
                             isEditing={isEditing && localDimension.isValueRange}
                             onEditableSave={(value) => {
+                                const partial: Partial<VariableFontDimension> = {
+                                    editorDefault: parseInt(value),
+                                    value: parseInt(value),
+                                };
+
+                                setLocalDimension({ ...localDimension, ...partial });
+
                                 dispatch({
                                     type: ActionType.EditDimensions,
                                     payload: {
                                         id,
                                         tag: localDimension.tag,
-                                        partial: {
-                                            editorDefault: parseInt(value),
-                                            value: parseInt(value),
-                                        },
+                                        partial,
                                     },
                                 });
                             }}
@@ -203,14 +209,18 @@ export const RangeSetting: FC<RangeSettingProps> = ({
                         <EditableTextWrapper
                             isEditing={isEditing}
                             onEditableSave={(value) => {
+                                const partial: Partial<VariableFontDimension> = {
+                                    value: parseInt(value),
+                                };
+
+                                setLocalDimension({ ...localDimension, ...partial });
+
                                 dispatch({
                                     type: ActionType.EditDimensions,
                                     payload: {
                                         id,
                                         tag: localDimension.tag,
-                                        partial: {
-                                            value: parseInt(value),
-                                        },
+                                        partial,
                                     },
                                 });
                             }}
@@ -236,6 +246,9 @@ export const RangeSetting: FC<RangeSettingProps> = ({
                                 if (localDimension.defaultValue < valueAsNumber) {
                                     partial.defaultValue = valueAsNumber - STEP;
                                 }
+
+                                setLocalDimension({ ...localDimension, ...partial });
+
                                 dispatch({
                                     type: ActionType.EditDimensions,
                                     payload: {

--- a/src/components/StyleEntry/StyleEntry.module.css
+++ b/src/components/StyleEntry/StyleEntry.module.css
@@ -17,7 +17,11 @@
     flex-grow: 1;
 }
 
-.style-entry__header div[data-test-id="editable-node-container"] {
+.style-entry__header button {
+    text-align: left;
+}
+
+.style-entry__header div[data-test-id='editable-node-container'] {
     justify-content: flex-start;
     display: inline-flex;
 }


### PR DESCRIPTION
There were 2 minor bugs

- Range Toggle change wasn't updated (just after a hard reload) if you changed first the range or the value / default
- Input Fields (min/default/value/max) weren't updated directly via the field